### PR TITLE
Fix gemspec to use extconf.rb with rb_sys to build rust extension

### DIFF
--- a/gem/rack-dev_insight.gemspec
+++ b/gem/rack-dev_insight.gemspec
@@ -19,9 +19,12 @@ Gem::Specification.new do |spec|
     'changelog_uri' => 'https://github.com/takaebato/rack-dev_insight/blob/master/CHANGELOG.md',
     'rubygems_mfa_required' => 'true'
   }
-  spec.files = Dir['lib/**/*.rb', 'ext/**/*.{rs,toml,lock,rb}', 'Cargo.toml', 'Cargo.lock']
+  spec.files = Dir['{lib,ext}/**/*', 'Cargo.*']
+  spec.files.reject! { |f| File.directory?(f) }
+  spec.files.reject! { |f| f =~ /\.(dll|so|dylib|lib|bundle)\Z/ }
   spec.require_paths = ['lib']
-  spec.extensions = ['ext/rack_dev_insight/Cargo.toml']
+  spec.extensions = ['ext/rack_dev_insight/extconf.rb']
 
   spec.add_dependency 'rack'
+  spec.add_dependency 'rb_sys', '~> 0.9.85'
 end


### PR DESCRIPTION
Cargo builder creates shared object to `lib/dirname/cratename.dlext`, but it is not ideal for our situation. https://github.com/rubygems/rubygems/pull/6298#issue-1552606544

Migrate from cargo builder to extconf and rb_sys, which can determine arbitrary destination. https://github.com/rubygems/rubygems/issues/6204#issuecomment-1368518883